### PR TITLE
Support ARM architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
+CROSS_COMPILE_SUFFIX ?= -linux-gnueabi
 CC = $(CROSS_COMPILE)gcc
 CFLAGS = -std=gnu99 -Wall -Werror -g -D_GNU_SOURCE
 CFLAGS += -DPROG_HEADER=prog_header
 
 OUT = out
 
+ARCH = x86_64 arm
+CHECK_ARCH = $(addprefix check_, $(ARCH))
 BIN = $(OUT) $(OUT)/test_lib.so $(OUT)/loader
 all: $(BIN)
 
@@ -24,6 +27,12 @@ $(OUT)/%.o: %.c
 LOADER_OBJS = $(OUT)/loader.o $(OUT)/test_loader.o
 $(OUT)/loader: $(LOADER_OBJS)
 	$(CC) -o $@ $(LOADER_OBJS)
+
+$(ARCH):
+	@make CROSS_COMPILE=$@$(CROSS_COMPILE_SUFFIX)- all
+
+$(CHECK_ARCH): check_% : %
+	@(cd $(OUT) && qemu-$* -L /usr/$*$(CROSS_COMPILE_SUFFIX)/ ./loader)
 
 check: $(BIN)
 	@(cd $(OUT) && ./loader)

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ OUT = out
 
 ARCH = x86_64 arm
 CHECK_ARCH = $(addprefix check_, $(ARCH))
+CHECK_CC_ARCH = $(addprefix check_cc_, $(ARCH))
 BIN = $(OUT) $(OUT)/test_lib.so $(OUT)/loader
 all: $(BIN)
 
@@ -28,7 +29,13 @@ LOADER_OBJS = $(OUT)/loader.o $(OUT)/test_loader.o
 $(OUT)/loader: $(LOADER_OBJS)
 	$(CC) -o $@ $(LOADER_OBJS)
 
-$(ARCH):
+$(CHECK_CC_ARCH):
+	@echo "Check cross compiler exist or not"
+	@echo "CROSS_COMPILE_SUFFIX=$(CROSS_COMPILE_SUFFIX)"
+	@which $(patsubst check_cc_%,%,$@)$(CROSS_COMPILE_SUFFIX)-gcc
+	@echo "Pass"
+
+$(ARCH): % : check_cc_%
 	@make CROSS_COMPILE=$@$(CROSS_COMPILE_SUFFIX)- all
 
 $(CHECK_ARCH): check_% : %

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+CC = $(CROSS_COMPILE)gcc
 CFLAGS = -std=gnu99 -Wall -Werror -g -D_GNU_SOURCE
 CFLAGS += -DPROG_HEADER=prog_header
 

--- a/arch/arm.h
+++ b/arch/arm.h
@@ -1,0 +1,36 @@
+#ifndef _MIN_DL_ARM_H_
+#define _MIN_DL_ARM_H_
+
+#include <link.h>
+
+#define _PUSH_S(x) push x
+#define _PUSH(x,y) \
+  ldr r3, =x   \n  \
+  ldr r2, [r3] \n  \
+  push {r2}
+#define _PUSH_IMM(x) \
+  mov r0, ES_HASH()x  \n  \
+  push {r0}
+#define _PUSH_STACK_STATE push {r11, lr}
+#define _POP_STACK_STATE  pop {r11, lr}
+#define _POP_S(x)   pop x
+#define _POP(x,y)   ldr x, [y]
+#define _JMP_S(x)   b x
+#define _JMP_REG(x) bx x
+#define _JMP(x,y) \
+  ldr r3, =x        \n   \
+  ldr r2, [r3]      \n   \
+  bx r2
+#define _CALL(x)    bl x
+#define REG_IP      ip
+#define REG_ARG_1   {r0}
+#define REG_ARG_2   {r1}
+#define REG_RET  r0
+#define LABEL_PREFIX  "="
+#define SYS_ADDR_ATTR "word"
+
+typedef ElfW(Rel) ElfW_Reloc;
+#define ELFW_DT_RELW   DT_REL
+#define ELFW_DT_RELWSZ DT_RELSZ
+
+#endif

--- a/arch/x86_64.h
+++ b/arch/x86_64.h
@@ -1,0 +1,28 @@
+#ifndef _MIN_DL_X86_64_H_
+#define _MIN_DL_X86_64_H_
+
+#include <link.h>
+
+#define _PUSH_S(x)   pushq x
+#define _PUSH(x,y)   pushq x(y)
+#define _PUSH_IMM(x) pushq $##x
+#define _PUSH_STACK_STATE
+#define _POP_STACK_STATE
+#define _POP_S(x)  pop x
+#define _POP(x,y)  pop x
+#define _JMP_S(x)  jmp x
+#define _JMP_REG(x) _JMP_S(x)
+#define _JMP(x,y)  jmp *x(y)
+#define _CALL(x)   call x
+#define REG_IP     %rip
+#define REG_ARG_1  %rdi
+#define REG_ARG_2  %rsi
+#define REG_RET    *%rax
+#define SYS_ADDR_ATTR "quad"
+#define LABEL_PREFIX
+
+typedef ElfW(Rela) ElfW_Reloc;
+#define ELFW_DT_RELW   DT_RELA
+#define ELFW_DT_RELWSZ DT_RELASZ
+
+#endif

--- a/lib-support.h
+++ b/lib-support.h
@@ -9,19 +9,26 @@
 #if defined(__x86_64__)
 #define _PUSH_S(x) pushq x
 #define _PUSH(x,y) pushq x(y)
+#define _POP_S(x)  pop x
+#define _POP(x,y)  pop x
 #define _JMP_S(x)  jmp x
 #define _JMP(x,y)  jmp *x(y)
+#define _CALL(x)   call x
 #define REG_IP     %rip
 
 #elif defined(__arm__)
 #define _PUSH_S(x) push x
 #define _PUSH(x,y) ldr y, [x]
+#define _POP_S(x)  pop x
+#define _POP(x,y)  str x, [y]
 #define _JMP_S(x)  b x
 #define _JMP(x,y)  b x
+#define _CALL(x)   bl x
 #define REG_IP     ip
 
 #elif defined(__aarch64__)
 #define _PUSH(x,y) stp x ,y ,[sp, #-16]!
+#define _CALL(x)   bl x
 #else
 #error "Unsupported architecture"
 #endif
@@ -30,6 +37,9 @@
 #define PUSH(x,y) XSTR(_PUSH(x,y))
 #define JMP_S(x)  XSTR(_JMP_S(x))
 #define JMP(x,y)  XSTR(_JMP(x,y))
+#define POP_S(x)  XSTR(_POP_S(x))
+#define POP(x,y)  XSTR(_POP(x,y))
+#define CALL(x)   XSTR(_CALL(x))
 
 typedef void *(*plt_resolver_t)(void *handle, int import_id);
 

--- a/lib-support.h
+++ b/lib-support.h
@@ -14,53 +14,9 @@
 #endif
 
 #if defined(__x86_64__)
-#define _PUSH_S(x)   pushq x
-#define _PUSH(x,y)   pushq x(y)
-#define _PUSH_IMM(x) pushq $##x
-#define _POP_S(x)  pop x
-#define _POP(x,y)  pop x
-#define _JMP_S(x)  jmp x
-#define _JMP_REG(x) _JMP_S(x)
-#define _JMP(x,y)  jmp *x(y)
-#define _CALL(x)   call x
-#define REG_IP     %rip
-#define REG_ARG_1  %rdi
-#define REG_ARG_2  %rsi
-#define REG_RET    *%rax
-#define SYS_ADDR_ATTR "quad"
-#define LABEL_PREFIX
-
-#define PUSH_STACK_STATE
-#define POP_STACK_STATE
-
+#include "arch/x86_64.h"
 #elif defined(__arm__)
-#define _PUSH_S(x) push x
-#define _PUSH(x,y) \
-  ldr r3, =x   \n  \
-  ldr r2, [r3] \n  \
-  push {r2}
-#define _PUSH_IMM(x) \
-  mov r0, ES_HASH()x  \n  \
-  push {r0}
-#define _POP_S(x)   pop x
-#define _POP(x,y)   ldr x, [y]
-#define _JMP_S(x)   b x
-#define _JMP_REG(x) bx x
-#define _JMP(x,y) \
-  ldr r3, =x        \n   \
-  ldr r2, [r3]      \n   \
-  bx r2
-#define _CALL(x)    bl x
-#define REG_IP      ip
-#define REG_ARG_1   {r0}
-#define REG_ARG_2   {r1}
-#define REG_RET  r0
-#define LABEL_PREFIX  "="
-#define SYS_ADDR_ATTR "word"
-
-#define PUSH_STACK_STATE "push {r11, lr}"
-#define POP_STACK_STATE  "pop {r11, lr}"
-
+#include "arch/arm.h"
 #else
 #error "Unsupported architecture"
 #endif

--- a/lib-support.h
+++ b/lib-support.h
@@ -3,6 +3,34 @@
 
 #include <stdint.h>
 
+#define STR(x)  #x
+#define XSTR(x) STR(x)
+
+#if defined(__x86_64__)
+#define _PUSH_S(x) pushq x
+#define _PUSH(x,y) pushq x(y)
+#define _JMP_S(x)  jmp x
+#define _JMP(x,y)  jmp *x(y)
+#define REG_IP     %rip
+
+#elif defined(__arm__)
+#define _PUSH_S(x) push x
+#define _PUSH(x,y) ldr y, [x]
+#define _JMP_S(x)  b x
+#define _JMP(x,y)  b x
+#define REG_IP     ip
+
+#elif defined(__aarch64__)
+#define _PUSH(x,y) stp x ,y ,[sp, #-16]!
+#else
+#error "Unsupported architecture"
+#endif
+
+#define PUSH_S(x) XSTR(_PUSH_S(x))
+#define PUSH(x,y) XSTR(_PUSH(x,y))
+#define JMP_S(x)  XSTR(_JMP_S(x))
+#define JMP(x,y)  XSTR(_JMP(x,y))
+
 typedef void *(*plt_resolver_t)(void *handle, int import_id);
 
 struct program_header {
@@ -14,38 +42,28 @@ struct program_header {
 
 extern void *pltgot_imports[];
 
-#if defined(__x86_64__)
-#define MDL_PLT_BEGIN                                     \
-    asm(".pushsection \".text\",\"ax\",@progbits\n"       \
-        "slowpath_common:\n"                              \
-        "pushq plt_handle(%rip)\n"                        \
-        "jmp *plt_trampoline(%rip)\n"                     \
-        ".popsection\n" /* start of PLTGOT table. */      \
-        ".pushsection \".my_pltgot\",\"aw\",@progbits\n"  \
-        "pltgot_imports:\n"                               \
-        ".popsection\n");
+#define MDL_PLT_BEGIN                                        \
+    asm(".pushsection \".text\",\"ax\",@progbits"       "\n" \
+        "slowpath_common:"                              "\n" \
+        PUSH(plt_handle, REG_IP)                        "\n" \
+        JMP(plt_trampoline, REG_IP)                     "\n" \
+        ".popsection" /* start of PLTGOT table. */      "\n" \
+        ".pushsection \".my_pltgot\",\"aw\",@progbits"  "\n" \
+        "pltgot_imports:"                               "\n" \
+        ".popsection"                                   "\n");
 
-#define MDL_PLT_ENTRY(number, name)                       \
-    asm(".pushsection \".text\",\"ax\",@progbits\n" #name \
-        ":\n"                                             \
-        "jmp *pltgot_" #name                              \
-        "(%rip)\n"                                        \
-        "slowpath_" #name                                 \
-        ":\n"                                             \
-        "pushq $" #number                                 \
-        "\n"                                              \
-        "jmp slowpath_common\n"                           \
-        ".popsection\n" /* entry in PLTGOT table */       \
-        ".pushsection \".my_pltgot\",\"aw\",@progbits\n"  \
-        "pltgot_" #name                                   \
-        ":\n"                                             \
-        ".quad slowpath_" #name                           \
-        "\n"                                              \
-        ".popsection\n");
-
-#else
-#error Unsupported architecture
-#endif
+#define MDL_PLT_ENTRY(number, name)                          \
+    asm(".pushsection \".text\",\"ax\",@progbits"       "\n" \
+        #name ":"                                       "\n" \
+        JMP(pltgot_ ##name, REG_IP)                     "\n" \
+        "slowpath_" #name ":"                           "\n" \
+        PUSH_S($ ##number)                              "\n" \
+        JMP_S(slowpath_common)                          "\n" \
+        ".popsection" /* entry in PLTGOT table */       "\n" \
+        ".pushsection \".my_pltgot\",\"aw\",@progbits"  "\n" \
+        "pltgot_" #name ":"                             "\n" \
+        ".quad slowpath_" #name                         "\n" \
+        ".popsection"                                   "\n");
 
 #define MDL_DEFINE_HEADER(user_info_value)                \
     void *plt_trampoline;                                 \

--- a/lib-support.h
+++ b/lib-support.h
@@ -77,26 +77,26 @@ struct program_header {
 extern void *pltgot_imports[];
 
 #define MDL_PLT_BEGIN                                        \
-    asm(".pushsection \".text\",\"ax\",@progbits"       "\n" \
+    asm(".pushsection .text,\"ax\", \"progbits\""       "\n" \
         "slowpath_common:"                              "\n" \
         PUSH(plt_handle, REG_IP)                        "\n" \
         JMP(plt_trampoline, REG_IP)                     "\n" \
         ".popsection" /* start of PLTGOT table. */      "\n" \
-        ".pushsection \".my_pltgot\",\"aw\",@progbits"  "\n" \
+        ".pushsection .my_pltgot,\"aw\",\"progbits\""   "\n" \
         "pltgot_imports:"                               "\n" \
         ".popsection"                                   "\n");
 
 #define MDL_PLT_ENTRY(number, name)                          \
-    asm(".pushsection \".text\",\"ax\",@progbits"       "\n" \
+    asm(".pushsection .text,\"ax\", \"progbits\""       "\n" \
         #name ":"                                       "\n" \
         JMP(pltgot_ ##name, REG_IP)                     "\n" \
         "slowpath_" #name ":"                           "\n" \
-        PUSH_S($ ##number)                              "\n" \
+        PUSH_IMM($ ##number)                            "\n" \
         JMP_S(slowpath_common)                          "\n" \
         ".popsection" /* entry in PLTGOT table */       "\n" \
-        ".pushsection \".my_pltgot\",\"aw\",@progbits"  "\n" \
+        ".pushsection .my_pltgot,\"aw\",\"progbits\""   "\n" \
         "pltgot_" #name ":"                             "\n" \
-        ".quad slowpath_" #name                         "\n" \
+        ".quad " LABEL_PREFIX "slowpath_" #name         "\n" \
         ".popsection"                                   "\n");
 
 #define MDL_DEFINE_HEADER(user_info_value)                \

--- a/loader.c
+++ b/loader.c
@@ -15,15 +15,8 @@
 
 #define MAX_PHNUM 12
 
-#if defined(__x86_64__)
-typedef ElfW(Rela) ElfW_Reloc;
-#else
-typedef ElfW(Rel) ElfW_Reloc;
-#endif
 #define ELFW_R_TYPE(x) ELFW(R_TYPE)(x)
 #define ELFW_R_SYM(x) ELFW(R_SYM)(x)
-#define ELFW_DT_RELW DT_RELA
-#define ELFW_DT_RELWSZ DT_RELASZ
 
 struct __DLoader_Internal {
     uintptr_t load_bias;
@@ -308,18 +301,6 @@ dloader_p api_load(const char *filename)
     ElfW_Reloc *relocs =
         (ElfW_Reloc *)(load_bias + get_dynamic_entry(dynamic, ELFW_DT_RELW));
     size_t relocs_size = get_dynamic_entry(dynamic, ELFW_DT_RELWSZ);
-
-    /*
-     * FIXME
-     * There is no RELA in ARM instead of REL,
-     * someone should make the condition code better.
-     */
-    if (relocs_size == 0) {
-      relocs =
-        (ElfW_Reloc *)(load_bias + get_dynamic_entry(dynamic, DT_REL));
-      relocs_size = get_dynamic_entry(dynamic, DT_RELSZ);
-    }
-
     for (i = 0; i < relocs_size / sizeof(ElfW_Reloc); i++) {
         ElfW_Reloc *reloc = &relocs[i];
         int reloc_type = ELFW_R_TYPE(reloc->r_info);

--- a/loader.c
+++ b/loader.c
@@ -165,12 +165,12 @@ ElfW(Word) get_dynamic_entry(ElfW(Dyn) *dynamic, int field)
 }
 
 void plt_trampoline();
-asm(".pushsection \".text\",\"ax\",@progbits" "\n"
+asm(".pushsection .text,\"ax\",\"progbits\""  "\n"
     "plt_trampoline:"                         "\n"
-    POP_S(%rdi) /* Argument 1 */              "\n"
-    POP_S(%rsi) /* Argument 2 */              "\n"
+    POP_S(REG_ARG_1) /* Argument 1 */         "\n"
+    POP_S(REG_ARG_2) /* Argument 2 */         "\n"
     CALL(system_plt_resolver)                 "\n"
-    JMP_S(*%rax)                              "\n"
+    JMP_REG(REG_RET)                          "\n"
     ".popsection"                             "\n");
 
 void *system_plt_resolver(dloader_p o, int import_id)

--- a/loader.c
+++ b/loader.c
@@ -165,17 +165,13 @@ ElfW(Word) get_dynamic_entry(ElfW(Dyn) *dynamic, int field)
 }
 
 void plt_trampoline();
-#if defined(__x86_64__)
-asm(".pushsection \".text\",\"ax\",@progbits\n"
-    "plt_trampoline:\n"
-    "pop %rdi\n" /* Argument 1 */
-    "pop %rsi\n" /* Argument 2 */
-    "call system_plt_resolver\n"
-    "jmp *%rax\n"
-    ".popsection\n");
-#else
-#error "Unsupported architecture"
-#endif
+asm(".pushsection \".text\",\"ax\",@progbits" "\n"
+    "plt_trampoline:"                         "\n"
+    POP_S(%rdi) /* Argument 1 */              "\n"
+    POP_S(%rsi) /* Argument 2 */              "\n"
+    CALL(system_plt_resolver)                 "\n"
+    JMP_S(*%rax)                              "\n"
+    ".popsection"                             "\n");
 
 void *system_plt_resolver(dloader_p o, int import_id)
 {

--- a/loader.c
+++ b/loader.c
@@ -68,7 +68,7 @@ size_t my_strlen(const char *s)
 static void iov_int_string(int value, struct iovec *iov,
                            char *buf, size_t bufsz)
 {
-    static const char * const digit_lookup = "9876543210123456789" + 9;
+    static const char * const lookup = "9876543210123456789" + 9;
     char *p = &buf[bufsz];
     int negative = value < 0;
     do {

--- a/test_loader.c
+++ b/test_loader.c
@@ -47,7 +47,7 @@ int main()
 
     printf("OK!\n");
 
-    printf("Tes imported functions >\n");
+    printf("Test imported functions >\n");
     DLoader.set_plt_resolver(o, plt_resolver,
                              /* user_plt_resolver_handle */ o);
 


### PR DESCRIPTION
I'm boring in this Chinese New Year, so I try to write some code for fun.

Now min-dl works in cross compile for arm in following cross compiler 
```
make CROSS_COMPILE=arm-linux-gnueabi- check
 > gcc version 5.4.0 20160609 (Ubuntu/Linaro 5.4.0-6ubuntu1~16.04.4)
qemu-arm  -L /usr/arm-linux-gnueabi/ loader
 > qemu-arm version 2.5.0
```
I think we can also move all the system-specific assembly macro to independent header file
to make lib-support.h and loader.c more readable.
And also have many ways to refactor these messy code.
BTW, aarch64 is ready for coding, but I may have no more time to do this.

**There are also some ARM relocation issue**
1. REL instead of RELA
2. Global variables appear in .rel.dyn force our code needs to add WRITE permission in .text section
    >> maybe some compiler option can avoid, I'm not sure
