### PR TITLE
Support AARCH64 architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 CROSS_COMPILE_SUFFIX ?= -linux-gnueabi
+CROSS_COMPILE ?=
 CC = $(CROSS_COMPILE)gcc
 CFLAGS = -std=gnu99 -Wall -Werror -g -D_GNU_SOURCE
 CFLAGS += -DPROG_HEADER=prog_header
 
 OUT = out
 
-ARCH = x86_64 arm aarch64
+ARCH = $(basename $(notdir $(wildcard arch/*.h)))
 CHECK_ARCH = $(addprefix check_, $(ARCH))
 CHECK_CC_ARCH = $(addprefix check_cc_, $(ARCH))
 BIN = $(OUT) $(OUT)/test_lib.so $(OUT)/loader
@@ -30,10 +31,9 @@ $(OUT)/loader: $(LOADER_OBJS)
 	$(CC) -o $@ $(LOADER_OBJS)
 
 $(CHECK_CC_ARCH)::
-	@echo "Check cross compiler exist or not"
-	@echo "CROSS_COMPILE_SUFFIX=$(CROSS_COMPILE_SUFFIX)"
+	@echo "Check cross compiler CROSS_COMPILE_SUFFIX=$(CROSS_COMPILE_SUFFIX) exist or not"
+	@echo "If failed, please specify CROSS_COMPILE_SUFFIX"
 	@which $(patsubst check_cc_%,%,$@)$(CROSS_COMPILE_SUFFIX)-gcc
-	@echo "Pass"
 
 # The old version ld (< 2.28) will corrupt the global variable array which
 # contains another global variables with -shared option involved.

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS += -DPROG_HEADER=prog_header
 
 OUT = out
 
-ARCH = x86_64 arm
+ARCH = x86_64 arm aarch64
 CHECK_ARCH = $(addprefix check_, $(ARCH))
 CHECK_CC_ARCH = $(addprefix check_cc_, $(ARCH))
 BIN = $(OUT) $(OUT)/test_lib.so $(OUT)/loader
@@ -29,11 +29,22 @@ LOADER_OBJS = $(OUT)/loader.o $(OUT)/test_loader.o
 $(OUT)/loader: $(LOADER_OBJS)
 	$(CC) -o $@ $(LOADER_OBJS)
 
-$(CHECK_CC_ARCH):
+$(CHECK_CC_ARCH)::
 	@echo "Check cross compiler exist or not"
 	@echo "CROSS_COMPILE_SUFFIX=$(CROSS_COMPILE_SUFFIX)"
 	@which $(patsubst check_cc_%,%,$@)$(CROSS_COMPILE_SUFFIX)-gcc
 	@echo "Pass"
+
+# The old version ld (< 2.28) will corrupt the global variable array which
+# contains another global variables with -shared option involved.
+# For example, func_table will contain NULL after linking test_lib.so.
+check_cc_aarch64::
+	@$(eval LD_VERSION=$(shell echo `aarch64$(CROSS_COMPILE_SUFFIX)-ld -v | grep -oE '[^ ]+$$'`))
+	@$(eval LD_VERSION=$(shell echo $(LD_VERSION) | awk -F "." '{print $$1$$2}'))
+	@if [ $(LD_VERSION) -lt 228 ]; then \
+		echo "Error: aarch64$(CROSS_COMPILE_SUFFIX)-ld version must >= 2.28 in AARCH64."; \
+		return 1;\
+	fi;
 
 $(ARCH): % : check_cc_%
 	@make CROSS_COMPILE=$@$(CROSS_COMPILE_SUFFIX)- all

--- a/arch/aarch64.h
+++ b/arch/aarch64.h
@@ -1,0 +1,38 @@
+#ifndef _MIN_DL_AARCH64_H_
+#define _MIN_DL_AARCH64_H_
+
+#include <link.h>
+
+#define _PUSH_S(x) str x, [sp, ES_HASH()-16]!
+#define _PUSH(x,y) \
+  ldr x3, =x   \n  \
+  ldr x2, [x3] \n  \
+  str x2, [sp, ES_HASH()-16]!
+#define _PUSH_IMM(x) \
+  mov x0, ES_HASH()x  \n  \
+  str x0, [sp, ES_HASH()-16]!
+#define _PUSH_STACK_STATE stp x29, x30, [sp, #-16]!
+#define _POP_STACK_STATE  ldp x29, x30, [sp] \n \
+                          add sp, sp, ES_HASH()16
+#define _POP_S(x)   ldr x, [sp] \n \
+                    add sp, sp, ES_HASH()16
+#define _POP(x,y)   ldr x, [y]
+#define _JMP_S(x)   b x
+#define _JMP_REG(x) br x
+#define _JMP(x,y) \
+  ldr x3, =x   \n   \
+  ldr x2, [x3] \n  \
+  br x2
+#define _CALL(x)    bl x
+#define REG_IP      ip
+#define REG_ARG_1   x0
+#define REG_ARG_2   x1
+#define REG_RET     x0
+#define LABEL_PREFIX  "="
+#define SYS_ADDR_ATTR "quad"
+
+typedef ElfW(Rela) ElfW_Reloc;
+#define ELFW_DT_RELW   DT_RELA
+#define ELFW_DT_RELWSZ DT_RELASZ
+
+#endif

--- a/lib-support.h
+++ b/lib-support.h
@@ -17,6 +17,8 @@
 #include "arch/x86_64.h"
 #elif defined(__arm__)
 #include "arch/arm.h"
+#elif defined(__aarch64__)
+#include "arch/aarch64.h"
 #else
 #error "Unsupported architecture"
 #endif

--- a/loader.c
+++ b/loader.c
@@ -195,6 +195,7 @@ dloader_p api_load(const char *filename)
     switch (ehdr.e_machine) {
     case EM_X86_64:
     case EM_ARM:
+    case EM_AARCH64:
         break;
     default:
         fail(filename, "ELF file has wrong architecture!  ",
@@ -305,6 +306,7 @@ dloader_p api_load(const char *filename)
         switch (reloc_type) {
         case R_X86_64_RELATIVE:
         case R_ARM_RELATIVE:
+        case R_AARCH64_RELATIVE:
         {
             ElfW(Addr) *addr = (ElfW(Addr) *)(load_bias + reloc->r_offset);
             /*


### PR DESCRIPTION
Now support  aarch64, and almost nothing changed in `loader.c`.

To keep test_lib.so compiled correctly, the toolchain version is critical, see commit of ca2ab33.
GCC version `7.2.1 20171011 (Linaro GCC 7.2-2017.11) `with aarch64-linux-gnu-ld 
with version` 2.28.2.20170706` works fine

